### PR TITLE
Fixed an issue that an exception will be thrown when calling session.…

### DIFF
--- a/client/v1/session.js
+++ b/client/v1/session.js
@@ -108,7 +108,7 @@ Session.prototype.getAccount = function () {
 
 
 Session.prototype.destroy = function () {
-    this.cookiesStore.destroy();
+    this._cookiesStore.destroy();
     return new Request(this)
         .setMethod('POST')
         .setResource('logout')


### PR DESCRIPTION
…destroy()

The name for the cookiesStore object that is going to be destroyed is '_cookiesStore' instead of 'cookiesStore'.